### PR TITLE
Auto scroll to same position when going back to home page

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,6 +7,7 @@
 
   export let url = ''
   window.__navigator = navigate
+  let homePageScrollY
 </script>
 
 <Router url="{url}">
@@ -14,7 +15,9 @@
     <Route path="/example" component="{ExamplePage}" />
     <Route path="/:urlId/:mode" component="{WaifuPopPage}" />
     <Route path="/:urlId" component="{WaifuPopPage}" />
-    <Route path="/" component="{HomePage}" />
+    <Route path="/">
+      <HomePage bind:scrollY={homePageScrollY} />
+    </Route>
   </div>
   <SubmitWaifuNotAvailableModal />
 </Router>

--- a/src/HomePage.svelte
+++ b/src/HomePage.svelte
@@ -1,9 +1,12 @@
 <script>
-  import { onDestroy } from 'svelte'
+  import { onMount, onDestroy } from 'svelte'
   import { Link } from 'svelte-routing'
   import PageHead from './PageHead.svelte'
   import { getWaifuList, syncServerWaifuEvent } from './waifu/WaifuManager'
   import { formatNumber } from './utils/formatter'
+
+  export let scrollY = 0
+  let lastScrollY = scrollY
 
   let waifuList = []
 
@@ -15,10 +18,15 @@
     waifuList = newList
   })
 
+  onMount(() => {
+    scrollY = lastScrollY
+  })
   onDestroy(() => {
     unsubscribeSyncEvent()
   })
 </script>
+
+<svelte:window bind:scrollY={scrollY} />
 
 <PageHead />
 


### PR DESCRIPTION
It does not auto scroll to the same position as last if clicking home page link on waifu page bottom or going back to previous page in Chrome on PC.